### PR TITLE
consolidated s390 device configuration - step 1: migration

### DIFF
--- a/dasdconfmigrate.sh
+++ b/dasdconfmigrate.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: MIT
+# Copyright IBM Corp. 2023
+
+# This is just a wrapper to migrate old /etc/dasd.conf to the new
+# consolidated persistent configuration of s390 devices with chzdev.
+
+CONFIG=/etc/dasd.conf
+PATH=/sbin:/bin
+export PATH
+
+DATE=$(date --iso-8601=seconds)
+PREFIX="${CONFIG}.${DATE}.migrated-to-chzdev"
+
+if [ -f "$CONFIG" ]; then
+    # show migration output to users and log it into file
+    exec > >(tee "${PREFIX}.log") 2>&1
+    sed 'y/ABCDEF/abcdef/' < $CONFIG | while read -r line; do
+        case $line in
+            \#*) ;;
+            *)
+                [ -z "$line" ] && continue
+		# shellcheck disable=SC2086
+                set -- $line
+
+		chzdev --enable --active --persistent dasd "$@" --yes --no-root-update --force --no-settle
+		case $? in
+		    0)
+			# If device exists and could be actively enabled,
+			# chzdev could infer the actual dasd device type; done.
+			continue
+			;;
+		esac
+		# Configure persistently only to allow migration of
+		# configuration for devices that currently do not exist.
+		# Chzdev cannot infer the actual dasd device type for an
+		# absent device. Therefore, create duplicate configurations
+		# for both dasd-eckd and dasd-fba, so either one of them
+		# can enable such device when it appears.
+		chzdev --enable --persistent dasd-eckd "$@" --yes --no-root-update --force --no-settle
+		chzdev --enable --persistent dasd-fba "$@" --yes --no-root-update --force --no-settle
+                ;;
+        esac
+    done
+    mv "$CONFIG" "$CONFIG"."$DATE".migrated-to-chzdev
+    echo "dasdconfmigrate.sh: Information: Your persistent dasd device configuration file $CONFIG was migrated to the new consolidated mechanism. From now on, please use lszdev and chzdev from s390utils instead. To finally complete the migration, please run: kdumpctl rebuild; systemctl restart kdump; dracut -f; zipl"
+fi

--- a/s390utils.spec
+++ b/s390utils.spec
@@ -35,6 +35,8 @@ Source21:       https://fedorapeople.org/cgit/sharkcz/public_git/utils.git/tree/
 Source23:       20-zipl-kernel.install
 Source24:       52-zipl-rescue.install
 Source25:       91-zipl.install
+Source26:       https://fedorapeople.org/cgit/sharkcz/public_git/utils.git/tree/zfcpconfmigrate.sh
+
 
 %if %{with signzipl}
 %define pesign_name redhatsecureboot302
@@ -157,6 +159,7 @@ mv %{buildroot}%{_datadir}/s390-tools/netboot/mk-s390image %{buildroot}%{_bindir
 mkdir -p %{buildroot}{/boot,%{_udevrulesdir},%{_sysconfdir}/{profile.d,sysconfig},%{_prefix}/lib/modules-load.d}
 install -p -m 644 zipl/boot/tape0.bin %{buildroot}/boot/tape0
 install -p -m 755 %{SOURCE5} %{buildroot}%{_sbindir}
+install -p -m 755 %{SOURCE26} %{buildroot}%{_sbindir}
 install -p -m 755 %{SOURCE13} %{buildroot}%{_sbindir}
 install -p -m 755 %{SOURCE21} %{buildroot}%{_sbindir}
 install -p -m 644 %{SOURCE7} %{buildroot}%{_udevrulesdir}/56-zfcp.rules
@@ -272,6 +275,7 @@ This package provides minimal set of tools needed to system to boot.
 %{_sbindir}/dasdconf.sh
 %{_sbindir}/normalize_dasd_arg
 %{_sbindir}/zfcpconf.sh
+%{_sbindir}/zfcpconfmigrate.sh
 %{_sbindir}/device_cio_free
 %{_sbindir}/dasd_cio_free
 %{_sbindir}/zfcp_cio_free

--- a/s390utils.spec
+++ b/s390utils.spec
@@ -36,6 +36,7 @@ Source23:       20-zipl-kernel.install
 Source24:       52-zipl-rescue.install
 Source25:       91-zipl.install
 Source26:       https://fedorapeople.org/cgit/sharkcz/public_git/utils.git/tree/zfcpconfmigrate.sh
+Source27:       https://fedorapeople.org/cgit/sharkcz/public_git/utils.git/tree/dasdconfmigrate.sh
 
 
 %if %{with signzipl}
@@ -160,6 +161,7 @@ mkdir -p %{buildroot}{/boot,%{_udevrulesdir},%{_sysconfdir}/{profile.d,sysconfig
 install -p -m 644 zipl/boot/tape0.bin %{buildroot}/boot/tape0
 install -p -m 755 %{SOURCE5} %{buildroot}%{_sbindir}
 install -p -m 755 %{SOURCE26} %{buildroot}%{_sbindir}
+install -p -m 755 %{SOURCE27} %{buildroot}%{_sbindir}
 install -p -m 755 %{SOURCE13} %{buildroot}%{_sbindir}
 install -p -m 755 %{SOURCE21} %{buildroot}%{_sbindir}
 install -p -m 644 %{SOURCE7} %{buildroot}%{_udevrulesdir}/56-zfcp.rules
@@ -274,6 +276,7 @@ This package provides minimal set of tools needed to system to boot.
 %ghost %config(noreplace) %{_sysconfdir}/zfcp.conf
 %{_sbindir}/dasdconf.sh
 %{_sbindir}/normalize_dasd_arg
+%{_sbindir}/dasdconfmigrate.sh
 %{_sbindir}/zfcpconf.sh
 %{_sbindir}/zfcpconfmigrate.sh
 %{_sbindir}/device_cio_free

--- a/s390utils.spec
+++ b/s390utils.spec
@@ -37,6 +37,7 @@ Source24:       52-zipl-rescue.install
 Source25:       91-zipl.install
 Source26:       https://fedorapeople.org/cgit/sharkcz/public_git/utils.git/tree/zfcpconfmigrate.sh
 Source27:       https://fedorapeople.org/cgit/sharkcz/public_git/utils.git/tree/dasdconfmigrate.sh
+Source28:       https://fedorapeople.org/cgit/sharkcz/public_git/utils.git/tree/znetconfmigrate.sh
 
 
 %if %{with signzipl}
@@ -162,6 +163,7 @@ install -p -m 644 zipl/boot/tape0.bin %{buildroot}/boot/tape0
 install -p -m 755 %{SOURCE5} %{buildroot}%{_sbindir}
 install -p -m 755 %{SOURCE26} %{buildroot}%{_sbindir}
 install -p -m 755 %{SOURCE27} %{buildroot}%{_sbindir}
+install -p -m 755 %{SOURCE28} %{buildroot}%{_sbindir}
 install -p -m 755 %{SOURCE13} %{buildroot}%{_sbindir}
 install -p -m 755 %{SOURCE21} %{buildroot}%{_sbindir}
 install -p -m 644 %{SOURCE7} %{buildroot}%{_udevrulesdir}/56-zfcp.rules
@@ -279,6 +281,7 @@ This package provides minimal set of tools needed to system to boot.
 %{_sbindir}/dasdconfmigrate.sh
 %{_sbindir}/zfcpconf.sh
 %{_sbindir}/zfcpconfmigrate.sh
+%{_sbindir}/znetconfmigrate.sh
 %{_sbindir}/device_cio_free
 %{_sbindir}/dasd_cio_free
 %{_sbindir}/zfcp_cio_free

--- a/zfcpconfmigrate.sh
+++ b/zfcpconfmigrate.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: MIT
+# Copyright IBM Corp. 2023
+
+# This is just a wrapper to migrate old /etc/zfcp.conf to the new
+# consolidated persistent configuration of s390 devices with chzdev.
+
+CONFIG=/etc/zfcp.conf
+PATH=/bin:/sbin
+
+DATE=$(date --iso-8601=seconds)
+PREFIX="${CONFIG}.${DATE}.migrated-to-chzdev"
+
+if [ -f "$CONFIG" ]; then
+    # show migration output to users and log it into file
+    exec > >(tee "${PREFIX}.log") 2>&1
+    sed 'y/ABCDEF/abcdef/' < $CONFIG | while read -r line; do
+       case $line in
+	   \#*) ;;
+	   *)
+	       [ -z "$line" ] && continue
+	       # shellcheck disable=SC2086
+	       set -- $line
+	       if [ $# -eq 1 ]; then
+		   DEVICE=${1##*0x}
+		   chzdev --enable --persistent zfcp-host "$DEVICE" --yes --no-root-update --force --no-settle
+		   continue
+	       fi
+	       if [ $# -eq 5 ]; then
+		   DEVICE=$1
+		   #SCSIID=$2
+		   WWPN=$3
+		   #SCSILUN=$4
+		   FCPLUN=$5
+	       elif [ $# -eq 3 ]; then
+		   DEVICE=${1##*0x}
+		   WWPN=$2
+		   FCPLUN=$3
+	       fi
+	       chzdev --enable --persistent zfcp-lun "$DEVICE:$WWPN:$FCPLUN" --yes --no-root-update --force --no-settle
+	       ;;
+       esac
+   done
+   mv "$CONFIG" "$PREFIX"
+   echo "zfcpconfmigrate.sh: Information: Your persistent zfcp device configuration file $CONFIG was migrated to the new consolidated mechanism. From now on, please use lszdev and chzdev from s390utils instead. To finally complete the migration, please run: kdumpctl rebuild; systemctl restart kdump; dracut -f; zipl"
+fi

--- a/znetconfmigrate.sh
+++ b/znetconfmigrate.sh
@@ -1,0 +1,103 @@
+#! /bin/bash
+
+# SPDX-License-Identifier: MIT
+# Largely based on the old ccw_init script.
+
+# This is just a wrapper to migrate old s390 channel-attached network
+# device config to the new consolidated persistent configuration with
+# chzdev.
+
+DATE=$(date --iso-8601=seconds)
+
+# borrowed from network-scrips, initscripts along with the get_config_by_subchannel
+[ -z "$__sed_discard_ignored_files" ] && __sed_discard_ignored_files='/\(~\|\.bak\|\.old\|\.orig\|\.rpmnew\|\.rpmorig\|\.rpmsave\)$/d'
+
+get_configs ()
+{
+    LANG=C grep -E -i -l \
+        "^[[:space:]]*SUBCHANNELS=['\"]?([0-9]\.[0-9]\.[a-f0-9]+)(,[0-9]\.[0-9]\.[a-f0-9]+){1,2}['\"]?([[:space:]]+#|[[:space:]]*$)" \
+        /etc/sysconfig/network-scripts/ifcfg-* \
+        | LC_ALL=C sed -e "$__sed_discard_ignored_files"
+}
+
+get_configs_nm ()
+{
+    LANG=C grep -E -i -l \
+        "^s390-subchannels=([0-9]\.[0-9]\.[a-f0-9]+;){2,3}$" \
+        /etc/NetworkManager/system-connections/*.nmconnection \
+        | LC_ALL=C sed -e "$__sed_discard_ignored_files"
+}
+
+migrate ()
+{
+# translate variables from the interface config files to OPTIONS
+if [ -n "$PORTNAME" ]; then
+        if [ "$NETTYPE" = "lcs" ]; then
+		OPTIONS="$OPTIONS portno=$PORTNAME"
+        else
+		OPTIONS="$OPTIONS portname=$PORTNAME"
+        fi
+fi
+if [ "$NETTYPE" = "ctc" -a -n "$CTCPROT" ]; then
+	OPTIONS="$OPTIONS protocol=$CTCPROT"
+fi
+
+# SUBCHANNELS is only set on mainframe ccwgroup devices
+[ -z "$SUBCHANNELS" -o -z "$NETTYPE" ] && return
+
+SUBCHANNELS=$(echo "$SUBCHANNELS" | tr ',' ':')
+
+# shellcheck disable=SC2086
+chzdev --enable --persistent "$NETTYPE" "$SUBCHANNELS" $OPTIONS --yes --no-root-update --force --no-settle
+
+# Leave all s390-specifics in original $CONFIG_FILE because NetworkManager
+# does something with  NETTYPE, PORTNAME, CTCPROT,  OPTIONS.
+# Definitively Leave SUBCHANNELS as it might serve as interface identifier key,
+# which is not HWADDR.
+
+echo "znetconfmigrate.sh: Information: Your low-level persistent s390 network device configuration $CONFIG_FILE was migrated to the new consolidated mechanism. From now on, please use lszdev and chzdev from s390utils instead. To finally complete the migration, please run: kdumpctl rebuild; systemctl restart kdump; dracut -f; zipl"
+
+# re-initialize global variables before next possible iteration loop
+NETTYPE=""
+SUBCHANNELS=""
+OPTIONS=""
+PORTNAME=""
+CTCPROT=""
+}
+
+NOLOCALE="yes"
+
+CONFIG_FILES=$(get_configs)
+if [ -n "$CONFIG_FILES" ]; then
+    for CONFIG_FILE in $CONFIG_FILES; do
+	PREFIX="znet.${CONFIG_FILE##*/}.${DATE}.migrated-to-chzdev"
+	# show migration output to users and log it into file
+	exec > >(tee "$PREFIX.log") 2>&1
+	. "$CONFIG_FILE"
+	migrate
+    done
+else
+    CONFIG_FILES=$(get_configs_nm)
+    for CONFIG_FILE in $CONFIG_FILES; do
+	PREFIX="znet.${CONFIG_FILE##*/}.${DATE}.migrated-to-chzdev"
+	# show migration output to users and log it into file
+	exec > >(tee "$PREFIX.log") 2>&1
+	NETTYPE=$(sed -nr "/^\[ethernet\]/ { :l /^s390-nettype[ ]*=/ { s/.*=[ ]*//; p; q;}; n; b l;}" "$CONFIG_FILE")
+	SUBCHANNELS=$(sed -nr "/^\[ethernet\]/ { :l /^s390-subchannels[ ]*=/ { s/.*=[ ]*//; p; q;}; n; b l;}" "$CONFIG_FILE" | sed -e "s/;/,/g" -e "s/,$//")
+	OPTIONS=$(sed -nr "
+/^\[ethernet-s390-options\]/ {
+  n # skip matched line with beginning of section
+  :l # set label
+  /^[^#].*=.*/ { # match non-comment key value line
+    p # print
+  }
+  /^[ ]*\[/ { # match beginning of next section
+    q # quit
+  }
+  n # next
+  b l # branch to label
+}
+" "$CONFIG_FILE")
+	migrate
+    done
+fi


### PR DESCRIPTION
This is a factored-out first step of https://github.com/steffen-maier/s390utils/pull/1. The split is based on https://github.com/dracutdevs/dracut/pull/2534#issuecomment-1933744932.
The first three commits only add the migration scripts. They only depend on old chzdev functionality ~, which existed since s390-tools v1.33.0~. I think this could go into s390utils anytime and is a pre-req for some other package pull requests around "consolidated s390 device configuration".
More precisely, the used `chzdev` command line option `--no-settle` was only introduced with https://github.com/ibm-s390-linux/s390-tools/commit/f32bff96881a04bb68b895c23b13ae50daa9e7b4 ("zdev: Implement --no-settle ") in v2.5.0. And there have been some bugfixes since then (such as https://github.com/ibm-s390-linux/s390-tools/commit/2a1a821bb3941ddd341b52068d5c05e06d907355 in v2.28.0). Anyway, what I'm trying to say is: something recent would be good but we don't need v2.31.0 (i.e. no dependency on https://github.com/ibm-s390-linux/s390-tools/pull/158).

The second to last commit is an independent spec file cleanup, because I got confused by upstream vs. downstream files / udev rules.

The last commit is for packaging https://github.com/ibm-s390-linux/s390-tools/releases/tag/v2.31.0. It's not really related to the migration scripts and you can pick the last commit at your convenience when you rebase s390utils to upstream v2.31.0.

@jstodola @sharkcz this is a pseudo PR not meant to be merged but to provide a review comment opportunity for this patch set and or you to get commits from here into https://src.fedoraproject.org/rpms/s390utils.